### PR TITLE
🧹 fix missing event listener cleanup in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, onUnmounted } from 'vue';
 import Home from './components/Home.vue';
 import Trianglify from 'trianglify/dist/trianglify.bundle.js';
 
@@ -19,15 +19,22 @@ const updateBackground = () => {
   background.value.appendChild(pattern.toSVG());
 }
 
-onMounted(updateBackground);
-
-window.addEventListener('resize', event => {
+const handleResize = event => {
   const newWidth = round(event.target.innerWidth);
   const newHeight = round(event.target.innerHeight);
   if (newWidth === width.value && newHeight === height.value) return;
   width.value = newWidth;
   height.value = newHeight;
   updateBackground();
+};
+
+onMounted(() => {
+  updateBackground();
+  window.addEventListener('resize', handleResize);
+});
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize);
 });
 
 </script>


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is a missing event listener cleanup for the window 'resize' event in `src/App.vue`.

💡 **Why:** Adding global event listeners without cleanup can lead to memory leaks and unexpected behavior if the component is ever unmounted. Properly removing the listener in `onUnmounted` ensures better maintainability and follows Vue 3 best practices.

✅ **Verification:** The code was manually verified to ensure correct use of Vue 3 lifecycle hooks and `removeEventListener`. A code review confirmed the approach is correct and follows idiomatic patterns. Automated build/tests were attempted but limited by the sandbox environment.

✨ **Result:** The `App.vue` component now properly cleans up its window event listener, improving the overall code health and reliability of the application.

---
*PR created automatically by Jules for task [5897664949319696978](https://jules.google.com/task/5897664949319696978) started by @gkucmierz*